### PR TITLE
0.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,3 +180,11 @@ All notable changes to this project will be documented in this file.
 
 - let type-analyzer resolve logical expressions as number
 - let type-analyzer set proper label for binary expression
+
+## [0.5.12] - 18.07.2024
+
+- keep multiline comments in devMode when beautifying
+- fix beautify regarding multiline comments
+- fix beautify when having multiple commands in one line via semicolon
+- fix signature parser for multiline comments
+- add support for envar, file and line in type-analyzer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miniscript-vs",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "miniscript-vs",
-      "version": "0.5.11",
+      "version": "0.5.12",
       "dependencies": {
         "@vscode/debugadapter": "^1.51.1",
         "@vscode/debugprotocol": "^1.51.0",
@@ -15,11 +15,11 @@
         "greybel-core": "~1.7.0",
         "greybel-interpreter": "~4.8.2",
         "greybel-ms-intrinsics": "~1.7.0",
-        "greybel-transpiler": "~2.7.3",
+        "greybel-transpiler": "~2.8.0",
         "lru-cache": "^7.14.1",
         "miniscript-meta": "~1.2.3",
         "miniscript-textmate": "~0.2.1",
-        "miniscript-type-analyzer": "~0.5.4",
+        "miniscript-type-analyzer": "~0.6.0",
         "text-encoder-lite": "^2.0.0"
       },
       "devDependencies": {
@@ -4891,9 +4891,9 @@
       }
     },
     "node_modules/greybel-transpiler": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.7.3.tgz",
-      "integrity": "sha512-IKnymonnuPQF4a74yQlQacl593gxsSjsP2RIB9SpkCwgaLnSoYgpF+0rpVIDleIlu3jNQUHEv1iOod7tNScp1w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.8.0.tgz",
+      "integrity": "sha512-ynhDu7g/9B9g90VQZqy9wVIaHtbQZSSdppMQL+CXF525h2PWjHR1k6zKrhwji6tzWY/fbHE7Azq+H8PGVq2yLw==",
       "dependencies": {
         "blueimp-md5": "^2.19.0",
         "greybel-core": "~1.7.0"
@@ -5862,13 +5862,13 @@
       "integrity": "sha512-+UBlff1+v66qdI+0q74SLhCWmvmtKpQfddabeOq6l4kvTxStp6ruOnfhH9QTMVWAHNBYyUYIIcacwcXg2wvoyA=="
     },
     "node_modules/miniscript-type-analyzer": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.5.4.tgz",
-      "integrity": "sha512-gemAHDW2nXzBGFPx/i9uGDzQsmO+iLU3gfnV9fGL8LPVmLnGIT+TqmlIoluWDsVPC2/93Pzqz6NHqKP1giy3ew==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.6.0.tgz",
+      "integrity": "sha512-nOC8y4YO2iBm7AeO5hxDoscFG3gXVPrHdcOwkf5ceGIYlArKEJPXtaQ6xuJ3aJqAvYbhjHsjLgsuPWBq4jS65w==",
       "dependencies": {
         "comment-parser": "^1.4.1",
+        "greybel-core": "~1.7.0",
         "meta-utils": "~2.4.6",
-        "miniscript-core": "^0.7.0",
         "object-code": "^1.3.3"
       }
     },
@@ -10929,9 +10929,9 @@
       }
     },
     "greybel-transpiler": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.7.3.tgz",
-      "integrity": "sha512-IKnymonnuPQF4a74yQlQacl593gxsSjsP2RIB9SpkCwgaLnSoYgpF+0rpVIDleIlu3jNQUHEv1iOod7tNScp1w==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/greybel-transpiler/-/greybel-transpiler-2.8.0.tgz",
+      "integrity": "sha512-ynhDu7g/9B9g90VQZqy9wVIaHtbQZSSdppMQL+CXF525h2PWjHR1k6zKrhwji6tzWY/fbHE7Azq+H8PGVq2yLw==",
       "requires": {
         "blueimp-md5": "^2.19.0",
         "greybel-core": "~1.7.0"
@@ -11654,13 +11654,13 @@
       "integrity": "sha512-+UBlff1+v66qdI+0q74SLhCWmvmtKpQfddabeOq6l4kvTxStp6ruOnfhH9QTMVWAHNBYyUYIIcacwcXg2wvoyA=="
     },
     "miniscript-type-analyzer": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.5.4.tgz",
-      "integrity": "sha512-gemAHDW2nXzBGFPx/i9uGDzQsmO+iLU3gfnV9fGL8LPVmLnGIT+TqmlIoluWDsVPC2/93Pzqz6NHqKP1giy3ew==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/miniscript-type-analyzer/-/miniscript-type-analyzer-0.6.0.tgz",
+      "integrity": "sha512-nOC8y4YO2iBm7AeO5hxDoscFG3gXVPrHdcOwkf5ceGIYlArKEJPXtaQ6xuJ3aJqAvYbhjHsjLgsuPWBq4jS65w==",
       "requires": {
         "comment-parser": "^1.4.1",
+        "greybel-core": "~1.7.0",
         "meta-utils": "~2.4.6",
-        "miniscript-core": "^0.7.0",
         "object-code": "^1.3.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "soerenwehmeier@googlemail.com"
   },
   "icon": "icon.png",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "repository": {
     "type": "git",
     "url": "git@github.com:ayecue/miniscript-vs.git"
@@ -413,11 +413,11 @@
     "greybel-core": "~1.7.0",
     "greybel-interpreter": "~4.8.2",
     "greybel-ms-intrinsics": "~1.7.0",
-    "greybel-transpiler": "~2.7.3",
+    "greybel-transpiler": "~2.8.0",
     "lru-cache": "^7.14.1",
     "miniscript-meta": "~1.2.3",
     "miniscript-textmate": "~0.2.1",
-    "miniscript-type-analyzer": "~0.5.4",
+    "miniscript-type-analyzer": "~0.6.0",
     "text-encoder-lite": "^2.0.0"
   },
   "browserslist": "> 0.25%, not dead"


### PR DESCRIPTION
Includes:
- keep multiline comments in devMode when beautifying
- fix beautify regarding multiline comments
- fix beautify when having multiple commands in one line via semicolon
- fix signature parser for multiline comments
- add support for envar, file and line in type-analyzer